### PR TITLE
Version 3.0.0-alpha.9

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,7 +12,7 @@ module.exports = function (config) {
 		mime: { 'text/x-typescript': ['ts'] },
 		logLevel: config.LOG_INFO,
 		singleRun: true,
-		browserNoActivityTimeout: 120 * 1000,
+		browserNoActivityTimeout: 180 * 1000,
 
 		preprocessors: {
 			'src/**/*.ts': [ 'rollup' ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "virgil-crypto",
-  "version": "3.0.0-alpha.8",
+  "version": "3.0.0-alpha.9",
   "main": "dist/virgil-crypto.cjs.js",
   "browser": {
     "./dist/virgil-crypto.cjs.js": "./dist/virgil-crypto.browser.cjs.js",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "typings": "dist/types/index.d.ts",
   "files": [
     "dist",
-    "scripts/download-native-library.js"
+    "scripts/download-node-addon.js"
   ],
   "repository": {
     "type": "git",

--- a/src/VirgilCrypto.ts
+++ b/src/VirgilCrypto.ts
@@ -12,7 +12,20 @@ const _privateKeys = new WeakMap();
 const _setValue = WeakMap.prototype.set;
 const _getValue = WeakMap.prototype.get;
 
+/**
+ * Represents a private key for operations with {@link VirgilCrypto}.
+ *
+ * `VirgilPrivateKey` objects are not meant to be created directly using the `new` keyword.
+ * Use the {@link VirgilCrypto.generateKeys} and {@link VirgilCrypto.importPrivateKey} methods
+ * to create `VirgilPrivateKey` instances.
+ *
+ * @protected
+ */
 export class VirgilPrivateKey implements IPrivateKey {
+	/**
+	 * Private key identifier. Note that the private key and its
+	 * corresponding public key will have the same identifier.
+	 * */
 	identifier: Buffer;
 
 	constructor(identifier: Buffer, key: Buffer) {
@@ -21,8 +34,26 @@ export class VirgilPrivateKey implements IPrivateKey {
 	}
 }
 
+/**
+ * Represents a public key for operations with {@link VirgilCrypto}.
+ *
+ * `VirgilPublicKey` objects are not meant to be created directly using the `new` keyword.
+ * Use the {@link VirgilCrypto.generateKeys} and {@link VirgilCrypto.importPublicKey} methods
+ * to create `VirgilPublicKey` instances.
+ *
+ * @protected
+ */
 export class VirgilPublicKey implements IPublicKey {
+	/**
+	 * Public key identifier. Note that the public key and its
+	 * corresponding private key will have the same identifier.
+	 * */
 	identifier: Buffer;
+
+	/**
+	 * The public key material. Unlike the private keys, the public
+	 * key material is available as a property of the `PublicKey` object.
+	 */
 	key: Buffer;
 
 	constructor(identifier: Buffer, key: Buffer) {
@@ -31,26 +62,73 @@ export class VirgilPublicKey implements IPublicKey {
 	}
 }
 
+/**
+ * Gets the private key material of the given private key object from internal buffer.
+ * @param {VirgilPrivateKey} privateKey - Private key object.
+ * @returns {Buffer} - Private key material.
+ *
+ * @hidden
+ */
 function getPrivateKeyBytes(privateKey: VirgilPrivateKey): Buffer {
 	return _getValue.call(_privateKeys, privateKey);
 }
 
+/**
+ * Saves the private key material corresponding to the given private key object into
+ * internal buffer.
+ *
+ * @param {VirgilPrivateKey} privateKey - Private key object.
+ * @param {Buffer} bytes - Private key material.
+ *
+ * @hidden
+ */
 function setPrivateKeyBytes(privateKey: VirgilPrivateKey, bytes: Buffer) {
 	_setValue.call(_privateKeys, privateKey, bytes);
 }
 
-
+/**
+ * `VirgilCrypto` initialization options.
+ */
 export interface VirgilCryptoOptions {
+	/**
+	 * Indicates whether to use old algorithm to calculate keypair identifiers.
+	 */
 	useSha256Identifiers?: boolean;
+
+	/**
+	 * Type of keys to generate by default. Optional. Default is {@link KeyPairType.Default}.
+	 */
 	defaultKeyPairType?: KeyPairType;
 }
 
+/**
+ * Class implementing high-level cryptographic operations using Virgil Crypto Library.
+ */
 export class VirgilCrypto {
 
+	/**
+	 * Indicates whether to use old algorithm to calculate keypair identifiers.
+	 *
+	 * Current algorithm: first 8 bytes of SHA512 hash of public key in DER format.
+	 *
+	 * Old algorithm: SHA256 hash of public key in DER format.
+	 *
+	 * Use SHA256 identifiers only if you need to be compatible with version 2 of
+	 * this library (i.e. decrypt data that were encrypted using the version 2).
+	 *
+	 * Default is `false` (new algorithm)
+	 */
 	readonly useSha256Identifiers: boolean;
 
+	/**
+	 * Type of keys to generate by default.
+	 */
 	readonly defaultKeyPairType: KeyPairType;
 
+	/**
+	 * Creates a new instance of `VirgilCrypto` class.
+	 * @param {VirgilCryptoOptions} options
+	 */
 	constructor (
 		{ useSha256Identifiers = false, defaultKeyPairType = KeyPairType.Default }: VirgilCryptoOptions = {}
 	) {
@@ -58,6 +136,13 @@ export class VirgilCrypto {
 		this.defaultKeyPairType = defaultKeyPairType;
 	}
 
+	/**
+	 * Generates a new key pair.
+	 *
+	 * @param {KeyPairType} [type] - Optional type of the key pair.
+	 * 			See `KeyPairType` for available options. Default is Ed25519.
+	 * @returns {KeyPair} - The newly generated key pair.
+	 * */
 	generateKeys(type?: KeyPairType) {
 		type = type != null ? type : this.defaultKeyPairType;
 
@@ -72,6 +157,15 @@ export class VirgilCrypto {
 		};
 	}
 
+	/**
+	 * Creates a `VirgilPrivateKey` object from private key material in PEM or DER format.
+	 *
+	 * @param {Buffer|string} rawPrivateKey - The private key material as a `Buffer` or a
+	 * string in base64.
+	 * @param {string} [password] - Optional password the key material is encrypted with.
+	 *
+	 * @returns {VirgilPrivateKey} - The private key object.
+	 * */
 	importPrivateKey(rawPrivateKey: Buffer|string, password?: string) {
 		assert(
 			Buffer.isBuffer(rawPrivateKey) || typeof rawPrivateKey === 'string',
@@ -93,6 +187,14 @@ export class VirgilCrypto {
 		return new VirgilPrivateKey(identifier, privateKeyDer);
 	}
 
+	/**
+	 * Exports private key material in DER format from the given private key object.
+	 *
+	 * @param {VirgilPrivateKey} privateKey - The private key object.
+	 * @param {string} [password] - Optional password to encrypt the key material with.
+	 *
+	 * @returns {Buffer} - The private key material in DER format.
+	 * */
 	exportPrivateKey(privateKey: VirgilPrivateKey, password?: string) {
 		const privateKeyValue = getPrivateKeyBytes(privateKey);
 		assert(privateKeyValue !== undefined, 'Cannot export private key. `privateKey` is invalid');
@@ -104,6 +206,14 @@ export class VirgilCrypto {
 		return cryptoApi.encryptPrivateKey(privateKeyValue, Buffer.from(password, 'utf8'));
 	}
 
+	/**
+	 * Creates a `VirgilPublicKey` object from public key material in PEM or DER format.
+	 *
+	 * @param {Buffer|string} rawPublicKey - The public key material as a `Buffer` or
+	 * a {string} in base64.
+	 *
+	 * @returns {VirgilPublicKey} - The imported key handle.
+	 * */
 	importPublicKey(rawPublicKey: Buffer|string) {
 		assert(
 			Buffer.isBuffer(rawPublicKey) || typeof rawPublicKey === 'string',
@@ -116,6 +226,13 @@ export class VirgilCrypto {
 		return new VirgilPublicKey(identifier, publicKeyDer);
 	}
 
+	/**
+	 * Exports public key material in DER format from the given public key object.
+	 *
+	 * @param {VirgilPublicKey} publicKey - The public key object.
+	 *
+	 * @returns {Buffer} - The public key bytes.
+	 * */
 	exportPublicKey(publicKey: VirgilPublicKey) {
 		assert(
 			publicKey != null && publicKey.key != null,
@@ -125,6 +242,23 @@ export class VirgilCrypto {
 		return publicKey.key;
 	}
 
+	/**
+	 * Encrypts the data for the given public key(s) following the algorithm below:
+	 *
+	 * 1. Generates random AES-256 key - KEY1
+	 * 2. Encrypts the data with KEY1 using AES-256-GCM
+	 * 3. Generates ephemeral keypair for each recipient public key
+	 * 4. Uses Diffie-Hellman to obtain shared secret with each recipient public key & ephemeral private key
+	 * 5. Computes KDF to obtain AES-256 key - KEY2 - from shared secret for each recipient
+	 * 6. Encrypts KEY1 with KEY2 using AES-256-CBC for each recipient
+	 *
+	 * @param {Buffer|string} data - The data to be encrypted as a `Buffer`.
+	 * 			or a `string` in UTF8.
+	 * @param {VirgilPublicKey|VirgilPublicKey[]} publicKey - Public key or an array of public keys
+	 * of the intended recipients.
+	 *
+	 * @returns {Buffer} - Encrypted data.
+	 * */
 	encrypt(data: string|Buffer, publicKey: VirgilPublicKey|VirgilPublicKey[]) {
 		assert(
 			typeof data === 'string' || Buffer.isBuffer(data),
@@ -142,6 +276,19 @@ export class VirgilCrypto {
 		return cryptoApi.encrypt(data, publicKeys!);
 	}
 
+	/**
+	 * Decrypts the data with the given private key following the algorithm below:
+	 *
+	 * 1. Uses Diffie-Hellman to obtain shared secret with sender ephemeral public key & the `privateKey`
+	 * 2. Computes KDF to obtain AES-256 KEY2 from shared secret
+	 * 3. Decrypts KEY1 using AES-256-CBC and KEY2
+	 * 4. Decrypts data using KEY1 and AES-256-GCM
+	 *
+	 * @param {Buffer|string} encryptedData - The data to be decrypted as a `Buffer` or a `string` in base64.
+	 * @param {VirgilPrivateKey} privateKey - The private key to decrypt with.
+	 *
+	 * @returns {Buffer} - Decrypted data
+	 * */
 	decrypt(encryptedData: string|Buffer, privateKey: VirgilPrivateKey) {
 		assert(
 			typeof encryptedData === 'string' || Buffer.isBuffer(encryptedData),
@@ -157,6 +304,15 @@ export class VirgilCrypto {
 		});
 	}
 
+	/**
+	 * Calculates the hash of the given data.
+	 *
+	 * @param {Buffer|string} data - The data to calculate the hash of as a `Buffer` or a `string` in UTF-8.
+	 * @param {string} [algorithm] - Optional name of the hash algorithm to use.
+	 * See {@link HashAlgorithm} for available options. Default is SHA256.
+	 *
+	 * @returns {Buffer} - The hash.
+	 * */
 	calculateHash(data: Buffer|string, algorithm: HashAlgorithm = HashAlgorithm.SHA256) {
 		assert(Buffer.isBuffer(data) || typeof data === 'string',
 			'Cannot calculate hash. `data` must be a Buffer or a string in base64');
@@ -165,6 +321,13 @@ export class VirgilCrypto {
 		return cryptoApi.hash(data, algorithm);
 	}
 
+	/**
+	 * Extracts a public key from the private key handle.
+	 *
+	 * @param {VirgilPrivateKey} privateKey - The private key object to extract from.
+	 *
+	 * @returns {VirgilPublicKey} - The handle to the extracted public key.
+	 * */
 	extractPublicKey(privateKey: VirgilPrivateKey) {
 		const privateKeyValue = getPrivateKeyBytes(privateKey);
 
@@ -177,6 +340,20 @@ export class VirgilCrypto {
 		return new VirgilPublicKey(privateKey.identifier, publicKey);
 	}
 
+	/**
+	 * Calculates the signature of the data using the private key.
+	 *
+	 * NOTE: Returned value contains only digital signature, not data itself.
+	 *
+	 * NOTE: Data inside this function is guaranteed to be hashed with SHA512 at least one time.
+	 *
+	 * It's secure to pass raw data here.
+	 *
+	 * @param {Buffer|string} data - The data to be signed as a Buffer or a string in UTF-8.
+	 * @param {VirgilPrivateKey} privateKey - The private key object.
+	 *
+	 * @returns {Buffer} - The signature.
+	 * */
 	calculateSignature(data: Buffer|string, privateKey: VirgilPrivateKey) {
 		assert(
 			Buffer.isBuffer(data) || typeof data === 'string',
@@ -195,6 +372,17 @@ export class VirgilCrypto {
 		return cryptoApi.sign(data, { key: privateKeyValue });
 	}
 
+	/**
+	 * Verifies the provided data using the given signature and public key.
+	 * Note: Verification algorithm depends on PublicKey type. Default: EdDSA
+	 *
+	 * @param {Buffer|string} data - The data to be verified as a `Buffer` or a `string` in UTF-8.
+	 * @param {Buffer|string} signature - The signature as a `Buffer` or a `string` in base64.
+	 * @param {VirgilPublicKey} publicKey - The public key object.
+	 *
+	 * @returns {boolean} - True or False depending on the validity of the signature for the data
+	 * and public key.
+	 * */
 	verifySignature(data: Buffer|string, signature: Buffer|string, publicKey: VirgilPublicKey) {
 		assert(
 			Buffer.isBuffer(data) || typeof data === 'string',
@@ -218,6 +406,25 @@ export class VirgilCrypto {
 		return cryptoApi.verify(data, signature, publicKey);
 	}
 
+	/**
+	 * Calculates the signature on the data using the private key,
+	 * then encrypts the data along with the signature using the public key(s).
+	 *
+	 * 1. Generates signature depending on the type of private key
+	 * 2. Generates random AES-256 key - KEY1
+	 * 3. Encrypts both data and signature with KEY1 using AES-256-GCM
+	 * 4. Generates ephemeral key pair for each recipient
+	 * 5. Uses Diffie-Hellman to obtain shared secret with each recipient's public key & each ephemeral private key
+	 * 6. Computes KDF to obtain AES-256 key - KEY2 - from shared secret for each recipient
+	 * 7. Encrypts KEY1 with KEY2 using AES-256-CBC for each recipient
+	 *
+	 * @param {Buffer|string} data - The data to sign and encrypt as a Buffer or a string in UTF-8.
+	 * @param {VirgilPrivateKey} signingKey - The private key to use to calculate signature.
+	 * @param {VirgilPublicKey|VirgilPublicKey[]} encryptionKey - The public key of the intended recipient or an array
+	 * of public keys of multiple recipients.
+	 *
+	 * @returns {Buffer} - Encrypted data with attached signature.
+	 * */
 	signThenEncrypt(
 		data: Buffer|string,
 		signingKey: VirgilPrivateKey,
@@ -250,6 +457,27 @@ export class VirgilCrypto {
 		);
 	}
 
+	/**
+	 * Decrypts the data using the private key, then verifies decrypted data
+	 * using the attached signature and the given public key.
+	 *
+	 * 1. Uses Diffie-Hellman to obtain shared secret with sender ephemeral public key & recipient's private key
+	 * 2. Computes KDF to obtain AES-256 key - KEY2 - from shared secret
+	 * 3. Decrypts KEY1 using AES-256-CBC and KEY2
+	 * 4. Decrypts both data and signature using KEY1 and AES-256-GCM
+	 * 5. Verifies signature
+	 *
+	 * @param {Buffer|string} cipherData - The data to be decrypted and
+	 * verified as a Buffer or a string in base64.
+	 * @param {VirgilPrivateKey} decryptionKey - The private key object to use for decryption.
+	 *
+	 * @param {(VirgilPublicKey|VirgilPublicKey[])} verificationKey - The public key object
+	 * or an array of public key object to use to verify data integrity. If `verificationKey`
+	 * is an array, the attached signature must be valid for any one of them.
+	 *
+	 * @returns {Buffer} - Decrypted data iff verification is successful,
+	 * otherwise throws {@link IntegrityCheckFailedError}.
+	 * */
 	decryptThenVerify(
 		cipherData: Buffer|string,
 		decryptionKey: VirgilPrivateKey,
@@ -284,6 +512,15 @@ export class VirgilCrypto {
 		);
 	}
 
+	/**
+	 * @private
+	 * Calculates the keypair identifier form the public key material.
+	 * Takes first 8 bytes of SHA512 of public key DER if `useSHA256Identifiers=false`
+	 * and SHA256 of public key der if `useSHA256Identifiers=true`
+	 *
+	 * @param {Buffer} publicKeyData - Public key material.
+	 * @returns {Buffer} Key pair identifier
+	 */
 	private calculateKeypairIdentifier(publicKeyData: Buffer) {
 		if (this.useSha256Identifiers) {
 			return cryptoApi.hash(publicKeyData, HashAlgorithm.SHA256);

--- a/src/tests/encryption.test.ts
+++ b/src/tests/encryption.test.ts
@@ -5,7 +5,7 @@ const PASSWORD = Buffer.from('veryStrongPa$$0rd');
 const PLAINTEXT = Buffer.from('Plaintext secret message');
 
 describe('encrypt/decrypt', function () {
-	this.timeout(120 * 1000);
+	this.timeout(180 * 1000);
 
 	function encryptDecryptUsingKeyPair(data: Buffer, keysType: KeyPairType, password?: Buffer) {
 		const keyPair = cryptoApi.generateKeyPair({ password: password, type: keysType });


### PR DESCRIPTION
* Fixed script file downloading node addon not being included in the published package
* Restore mistakingly deleted reference comments in VirgilCrypto class
* Increase timeouts in browser tests due to encryption\decryption with RSA keys taking too long 