### PR TITLE
Fix: delete c++ object handles without deferring

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,12 +1,14 @@
 const bundleTypes = require('./scripts/rollup/bundle-types');
 const getRollupPlugins = require('./scripts/rollup/get-rollup-plugins');
 
+const entry = process.env.TEST_ASMJS_MEMORY_MGMT ? 'src/tests/memory/index.ts' : 'src/tests/index.ts';
+
 module.exports = function (config) {
 	config.set({
 		frameworks: [ 'mocha', 'chai' ],
 		autoWatch: false,
 		browsers: [ 'ChromeHeadless' ],
-		files: [ { pattern: 'src/tests/index.ts', watched: false } ],
+		files: [ { pattern: entry, watched: false } ],
 		colors: true,
 		reporters: [ 'progress' ],
 		mime: { 'text/x-typescript': ['ts'] },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "version": "npm run build",
     "test:node": "cross-env TS_NODE_FILES=true mocha --require chai/register-assert --require ts-node/register \"src/tests/**/*.test.ts\"",
     "test:browser": "karma start",
+    "test:browser:memory": "cross-env TEST_ASMJS_MEMORY_MGMT=true karma start",
     "test": "npm-run-all test:*",
     "postinstall": "npm run update:node",
     "docs": "typedoc src",

--- a/src/tests/memory/index.ts
+++ b/src/tests/memory/index.ts
@@ -1,0 +1,1 @@
+import './virgil-crypto-memory-mgmt.spec';

--- a/src/tests/memory/virgil-crypto-memory-mgmt.spec.ts
+++ b/src/tests/memory/virgil-crypto-memory-mgmt.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * @fileinfo
+ * Test that ensures that asm.js memory is properly freed in browsers.
+ * Number of iterations is chosen so that the tests do not run forever,
+ * but still provide a good enough proof that memory does not leak.
+ * This file has `.spec` prefix so that it doesn't run in node.js,
+ * where the memory is managed automatically.
+ */
+
+import { VirgilCrypto } from '../../index';
+
+describe('memory management in "sign" and "verify"', function() {
+	this.timeout(180 * 1000);
+
+	it('should not throw when called one thousand times', () => {
+		const virgilCrypto = new VirgilCrypto();
+		for (let i = 0; i < 1000; i += 1) {
+			const keyPair = virgilCrypto.generateKeys();
+			const message = 'message'.repeat(10);
+			const signature = virgilCrypto.calculateSignature(message, keyPair.privateKey);
+			const isValid = virgilCrypto.verifySignature(message, signature, keyPair.publicKey);
+			assert.isTrue(isValid, 'verifies signature');
+		}
+	});
+});
+
+describe('memory management in "encrypt" and "decrypt"', function() {
+	this.timeout(180 * 1000);
+
+	it('should not throw when called 5 hundred times', () => {
+		const virgilCrypto = new VirgilCrypto();
+		for (let i = 0; i < 500; i += 1) {
+			const keyPair = virgilCrypto.generateKeys();
+			const message = 'message'.repeat(10);
+			const ciphertext = virgilCrypto.encrypt(message, keyPair.publicKey);
+			const decrypted = virgilCrypto.decrypt(ciphertext, keyPair.privateKey);
+			assert.equal(decrypted.toString(), message, 'decrypts message');
+		}
+	});
+});
+
+describe('memory management in "signThenEncrypt" and "decryptThenVerify"', function() {
+	this.timeout(180 * 1000);
+
+	it('should not throw when called 5 hundred times', () => {
+		const virgilCrypto = new VirgilCrypto();
+		for (let i = 0; i < 500; i += 1) {
+			const keyPair = virgilCrypto.generateKeys();
+			const message = 'message'.repeat(10);
+			const ciphertext = virgilCrypto.signThenEncrypt(message, keyPair.privateKey, keyPair.publicKey);
+			const decrypted = virgilCrypto.decryptThenVerify(ciphertext, keyPair.privateKey, keyPair.publicKey);
+			assert.equal(decrypted.toString(), message, 'decrypts and verifies message');
+		}
+	});
+});
+
+describe('memory management in "signThenEncryptDetached" and "decryptThenVerifyDetached"', function() {
+	this.timeout(180 * 1000);
+
+	it('should not throw when called 5 hundred times', () => {
+		const virgilCrypto = new VirgilCrypto();
+		for (let i = 0; i < 500; i += 1) {
+			const keyPair = virgilCrypto.generateKeys();
+			const message = 'message'.repeat(10);
+			const { encryptedData, metadata } = virgilCrypto.signThenEncryptDetached(message, keyPair.privateKey, keyPair.publicKey);
+			const decrypted = virgilCrypto.decryptThenVerifyDetached(encryptedData, metadata, keyPair.privateKey, keyPair.publicKey);
+			assert.equal(decrypted.toString(), message, 'decrypts and verifies message');
+		}
+	});
+});


### PR DESCRIPTION
Fixes the "Cannot enlarge memory arrays..." issue, which could happen when verifying 200+ signatures in a loop.