### PR TITLE
Updates to Group Sessions

### DIFF
--- a/packages/base-crypto/src/VirgilCrypto.ts
+++ b/packages/base-crypto/src/VirgilCrypto.ts
@@ -591,12 +591,7 @@ export class VirgilCrypto implements ICrypto {
 
   generateGroupSession(groupId: Data): IGroupSession {
     const groupIdBytes = dataToUint8Array(groupId, 'utf8');
-    if (groupIdBytes.byteLength < MIN_GROUP_ID_BYTE_LENGTH) {
-      throw new Error(
-        `The given group Id is too short. Must be at least ${MIN_GROUP_ID_BYTE_LENGTH} bytes.`,
-      );
-    }
-
+    this.validateGroupId(groupIdBytes);
     const sessionId = computeSessionId(groupIdBytes);
     const initialEpoch = createInitialEpoch(sessionId);
 
@@ -615,6 +610,20 @@ export class VirgilCrypto implements ICrypto {
     }
 
     return createVirgilGroupSession(epochMessages.map(it => dataToUint8Array(it, 'base64')));
+  }
+
+  calculateGroupSessionId(groupId: Data) {
+    const groupIdBytes = dataToUint8Array(groupId, 'utf8');
+    this.validateGroupId(groupIdBytes);
+    return toBuffer(computeSessionId(groupIdBytes)).toString('hex');
+  }
+
+  private validateGroupId(groupId: Uint8Array) {
+    if (groupId.byteLength < MIN_GROUP_ID_BYTE_LENGTH) {
+      throw new Error(
+        `The given group Id is too short. Must be at least ${MIN_GROUP_ID_BYTE_LENGTH} bytes.`,
+      );
+    }
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/base-crypto/src/__tests__/VirgilCrypto.test.ts
+++ b/packages/base-crypto/src/__tests__/VirgilCrypto.test.ts
@@ -321,4 +321,22 @@ describe('VirgilCrypto', () => {
       expect(myGroup.getCurrentEpochNumber()).to.equal(theirGroup.getCurrentEpochNumber());
     });
   });
+
+  describe('calculateGroupSessionId', () => {
+    it('throws if groupId is less than 10 bytes long', () => {
+      expect(() => {
+        virgilCrypto.calculateGroupSessionId('short_id');
+      }, 'should have thrown').throws(Error);
+    });
+
+    it('returns correct as hex string', () => {
+      const expectedId = virgilCrypto
+        .calculateHash('i_am_long_enough_to_be_a_group_id', HashAlgorithm.SHA512)
+        .slice(0, 32);
+      const groupSessionId = virgilCrypto.calculateGroupSessionId(
+        'i_am_long_enough_to_be_a_group_id',
+      );
+      expect(groupSessionId).to.equal(expectedId.toString('hex'));
+    });
+  });
 });

--- a/packages/base-crypto/src/__tests__/VirgilCrypto.test.ts
+++ b/packages/base-crypto/src/__tests__/VirgilCrypto.test.ts
@@ -329,7 +329,7 @@ describe('VirgilCrypto', () => {
       }, 'should have thrown').throws(Error);
     });
 
-    it('returns correct as hex string', () => {
+    it('returns correct session id as hex string', () => {
       const expectedId = virgilCrypto
         .calculateHash('i_am_long_enough_to_be_a_group_id', HashAlgorithm.SHA512)
         .slice(0, 32);

--- a/packages/base-crypto/src/__tests__/VirgilGroupSession.test.ts
+++ b/packages/base-crypto/src/__tests__/VirgilGroupSession.test.ts
@@ -46,7 +46,7 @@ describe('group encryption', () => {
       const lastEpochData = group.export().pop();
       expect(lastEpochData).not.to.be.undefined;
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      expect(NodeBuffer.compare(lastEpochData!, data)).to.equal(0);
+      expect(lastEpochData!.toString('base64')).to.equal(data);
     });
   });
 
@@ -71,7 +71,7 @@ describe('group encryption', () => {
       const { epochNumber, sessionId, data } = group.parseMessage(encrypted);
       expect(epochNumber).to.equal(group.getCurrentEpochNumber());
       expect(sessionId).to.equal(group.getSessionId());
-      expect(NodeBuffer.compare(encrypted, data)).to.equal(0);
+      expect(encrypted.toString('base64')).to.equal(data);
     });
   });
 

--- a/packages/base-crypto/src/groups/helpers.ts
+++ b/packages/base-crypto/src/groups/helpers.ts
@@ -24,7 +24,7 @@ export function parseGroupSessionMessage(messageData: Uint8Array): IGroupSession
   const info: IGroupSessionMessageInfo = {
     epochNumber: message.getEpoch(),
     sessionId: toBuffer(message.getSessionId()).toString('hex'),
-    data: toBuffer(messageData),
+    data: toBuffer(messageData).toString('base64'),
   };
   message.delete();
   return info;

--- a/packages/crypto-types/index.d.ts
+++ b/packages/crypto-types/index.d.ts
@@ -27,7 +27,7 @@ export interface IKeyPair {
 export interface IGroupSessionMessageInfo {
   sessionId: string;
   epochNumber: number;
-  data: NodeBuffer;
+  data: string;
 }
 
 export interface IGroupSession {

--- a/packages/crypto-types/index.d.ts
+++ b/packages/crypto-types/index.d.ts
@@ -77,6 +77,7 @@ export interface ICrypto {
   ): NodeBuffer;
   generateGroupSession(groupId: Data): IGroupSession;
   importGroupSession(epochMessages: Data[]): IGroupSession;
+  calculateGroupSessionId(groupId: Data): string;
 }
 
 export interface IAccessTokenSigner {


### PR DESCRIPTION
* Changed the type of `IGroupSessionMessage` data property from `Buffer` to `string` - that's how it is stored in Keyknox - to simplify deserialization.

* Added ability to calculate 32 byte group session id from user-provided identifier. This is to be used in E3kit to download the shared group session from Keyknox so that users don't have to remember the session id and can load it by the same identifier provided during group creation.