### PR TITLE
Fix browser build

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -25,7 +25,7 @@
     "puppeteer": "^1.20.0",
     "regenerator-runtime": "^0.13.3",
     "serve-handler": "^6.1.1",
-    "virgil-crypto": "^4.0.0-alpha.14",
+    "virgil-crypto": "^4.0.0-alpha.17",
     "virgil-crypto-3": "npm:virgil-crypto@^3.2.6",
     "webpack": "^4.37.0"
   }

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -11,12 +11,13 @@
     "build": "webpack"
   },
   "dependencies": {
-    "virgil-crypto": "^4.0.0-alpha.14"
+    "virgil-crypto": "^4.0.0-alpha.17"
   },
   "devDependencies": {
     "file-loader": "^4.1.0",
     "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.39.1",
+    "webpack-bundle-analyzer": "^3.6.0",
     "webpack-cli": "^3.3.6",
     "webpack-dev-server": "^3.7.2"
   }

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -17,7 +17,6 @@
     "file-loader": "^4.1.0",
     "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.39.1",
-    "webpack-bundle-analyzer": "^3.6.0",
     "webpack-cli": "^3.3.6",
     "webpack-dev-server": "^3.7.2"
   }

--- a/examples/webpack/webpack.config.js
+++ b/examples/webpack/webpack.config.js
@@ -19,8 +19,5 @@ module.exports = {
       },
     ],
   },
-  plugins: [
-    new HtmlWebpackPlugin({ template: path.join(sourceRoot, 'index.html') }),
-    // new BundleAnalyzerPlugin(),
-  ],
+  plugins: [new HtmlWebpackPlugin({ template: path.join(sourceRoot, 'index.html') })],
 };

--- a/examples/webpack/webpack.config.js
+++ b/examples/webpack/webpack.config.js
@@ -19,5 +19,8 @@ module.exports = {
       },
     ],
   },
-  plugins: [new HtmlWebpackPlugin({ template: path.join(sourceRoot, 'index.html') })],
+  plugins: [
+    new HtmlWebpackPlugin({ template: path.join(sourceRoot, 'index.html') }),
+    // new BundleAnalyzerPlugin(),
+  ],
 };

--- a/packages/data-utils/package.json
+++ b/packages/data-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@virgilsecurity/data-utils",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Library that contains different functions / classes that are used for data manipulation in different Virgil Security libraries.",
   "main": "./dist/node.cjs.js",
   "module": "./dist/node.es.js",

--- a/packages/data-utils/package.json
+++ b/packages/data-utils/package.json
@@ -26,14 +26,14 @@
     "buffer": "^5.4.3"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^11.0.1",
-    "@rollup/plugin-node-resolve": "^7.0.0",
     "@types/chai": "^4.2.7",
     "@types/mocha": "^5.2.7",
     "chai": "^4.2.0",
     "mocha": "^7.0.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.29.1",
+    "rollup-plugin-commonjs": "^10.1.0",
+    "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-typescript2": "^0.25.3",
     "ts-node": "^8.6.2",
     "typescript": "^3.7.5"

--- a/packages/data-utils/rollup.config.js
+++ b/packages/data-utils/rollup.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
-const commonjs = require('@rollup/plugin-commonjs');
-const nodeResolve = require('@rollup/plugin-node-resolve');
+const commonjs = require('rollup-plugin-commonjs');
+const nodeResolve = require('rollup-plugin-node-resolve');
 const typescript = require('rollup-plugin-typescript2');
 
 const FORMAT = {

--- a/packages/init-utils/package.json
+++ b/packages/init-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@virgilsecurity/init-utils",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Initialization utility for Virgil Security Inc. libraries",
   "main": "./dist/init-utils.cjs.js",
   "module": "./dist/init-utils.es.js",

--- a/packages/pythia-crypto/package.json
+++ b/packages/pythia-crypto/package.json
@@ -32,15 +32,15 @@
     "@virgilsecurity/init-utils": "^0.3.0"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^11.0.1",
-    "@rollup/plugin-node-resolve": "^7.0.0",
     "@types/chai": "^4.2.7",
     "@types/mocha": "^5.2.7",
     "chai": "^4.2.0",
     "mocha": "^7.0.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.29.1",
+    "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-copy": "^3.2.1",
+    "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-re": "^1.0.7",
     "rollup-plugin-terser": "^5.2.0",
     "rollup-plugin-typescript2": "^0.25.3",

--- a/packages/pythia-crypto/package.json
+++ b/packages/pythia-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@virgilsecurity/pythia-crypto",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Virgil Pythia Crypto library.",
   "main": "./dist/node.cjs.js",
   "module": "./dist/node.es.js",
@@ -28,8 +28,8 @@
   "dependencies": {
     "@virgilsecurity/core-pythia": "^0.4.0",
     "@virgilsecurity/crypto-types": "^0.3.0",
-    "@virgilsecurity/data-utils": "^0.2.0",
-    "@virgilsecurity/init-utils": "^0.3.0"
+    "@virgilsecurity/data-utils": "^0.2.1",
+    "@virgilsecurity/init-utils": "^0.3.1"
   },
   "devDependencies": {
     "@types/chai": "^4.2.7",

--- a/packages/pythia-crypto/rollup.config.js
+++ b/packages/pythia-crypto/rollup.config.js
@@ -1,9 +1,9 @@
 const path = require('path');
 
 const builtinModules = require('builtin-modules');
-const commonjs = require('@rollup/plugin-commonjs');
+const commonjs = require('rollup-plugin-commonjs');
 const copy = require('rollup-plugin-copy');
-const nodeResolve = require('@rollup/plugin-node-resolve');
+const nodeResolve = require('rollup-plugin-node-resolve');
 const replace = require('rollup-plugin-re');
 const { terser } = require('rollup-plugin-terser');
 const typescript = require('rollup-plugin-typescript2');

--- a/packages/virgil-crypto/package.json
+++ b/packages/virgil-crypto/package.json
@@ -33,8 +33,6 @@
     "@virgilsecurity/sdk-crypto": "^0.5.0"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^11.0.1",
-    "@rollup/plugin-node-resolve": "^7.0.0",
     "@types/chai": "^4.2.7",
     "@types/mocha": "^5.2.7",
     "@types/node": "^13.1.8",
@@ -43,7 +41,9 @@
     "mocha": "^7.0.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.29.1",
+    "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-copy": "^3.2.1",
+    "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-re": "^1.0.7",
     "rollup-plugin-terser": "^5.2.0",
     "rollup-plugin-typescript2": "^0.25.3",

--- a/packages/virgil-crypto/package.json
+++ b/packages/virgil-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "virgil-crypto",
-  "version": "4.0.0-alpha.17",
+  "version": "4.0.0-alpha.18",
   "description": "Virgil JavaScript Crypto Library is a high-level cryptographic library that allows you to perform all necessary operations for secure storing and transferring data and everything required to become HIPAA and GDPR compliant.",
   "main": "./dist/node.cjs.js",
   "module": "./dist/node.es.js",
@@ -28,8 +28,8 @@
   "dependencies": {
     "@virgilsecurity/core-foundation": "^0.4.0",
     "@virgilsecurity/crypto-types": "^0.3.0",
-    "@virgilsecurity/data-utils": "^0.2.0",
-    "@virgilsecurity/init-utils": "^0.3.0",
+    "@virgilsecurity/data-utils": "^0.2.1",
+    "@virgilsecurity/init-utils": "^0.3.1",
     "@virgilsecurity/sdk-crypto": "^0.5.0"
   },
   "devDependencies": {

--- a/packages/virgil-crypto/rollup.config.js
+++ b/packages/virgil-crypto/rollup.config.js
@@ -1,9 +1,9 @@
 const path = require('path');
 
 const builtinModules = require('builtin-modules');
-const commonjs = require('@rollup/plugin-commonjs');
+const commonjs = require('rollup-plugin-commonjs');
 const copy = require('rollup-plugin-copy');
-const nodeResolve = require('@rollup/plugin-node-resolve');
+const nodeResolve = require('rollup-plugin-node-resolve');
 const replace = require('rollup-plugin-re');
 const { terser } = require('rollup-plugin-terser');
 const typescript = require('rollup-plugin-typescript2');


### PR DESCRIPTION
`rollup-plugin-commonjs` has been deprecated. It moved to rollup organisation and now available as `@rollup/plugin-commonjs`.

The problem is that new package has some kind of regression. That's why browser builds doesn't work properly.

This pull request rolls back them to previous versions.