### PR TITLE
Add missing property in Aes256Gcm typing

### DIFF
--- a/packages/core-foundation/index.d.ts
+++ b/packages/core-foundation/index.d.ts
@@ -228,6 +228,17 @@ declare namespace FoundationModules {
     authDecryptedLen(dataLen: number): number;
   }
 
+  export interface CipherInfo {
+    NONCE_LEN: number;
+    KEY_LEN: number;
+    KEY_BITLEN: number;
+    BLOCK_LEN: number;
+  }
+
+  export interface CipherAuthInfo {
+    AUTH_TAG_LEN: number;
+  }
+
   export class MessageInfoEditor extends FoundationObject {
     random: Random;
     setupDefaults(): void;
@@ -245,7 +256,9 @@ declare namespace FoundationModules {
     findData(key: Uint8Array): Uint8Array;
   }
 
-  export class Aes256Gcm extends FoundationObject implements AuthEncrypt, AuthDecrypt, Cipher {
+  export class Aes256Gcm extends FoundationObject
+    implements AuthEncrypt, AuthDecrypt, Cipher, CipherInfo, CipherAuthInfo {
+    NONCE_LEN: number;
     KEY_LEN: number;
     KEY_BITLEN: number;
     BLOCK_LEN: number;

--- a/packages/core-foundation/package.json
+++ b/packages/core-foundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@virgilsecurity/core-foundation",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Virgil Foundation",
   "main": "./node.cjs.js",
   "module": "./node.es.js",


### PR DESCRIPTION
I somehow missed `NONCE_LEN` property in previous version...
Also I made the types more accurate according to [model](https://github.com/VirgilSecurity/virgil-crypto-c/blob/master/codegen/models/project_foundation/implementor_mbedtls.xml#L77) in this pull request.