### PR TITLE
Add declaration for each bundle for every platform/crypto type/target

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,10 @@
     "husky": "^4.0.10",
     "lerna": "^3.20.2",
     "lint-staged": "^10.0.1",
+    "prettier": "1.18.2",
     "rollup-plugin-copy": "^3.2.1",
-    "prettier": "1.18.2"
+    "rollup-plugin-typescript2": "^0.25.3",
+    "typescript": "3.7.5"
   },
   "workspaces": [
     "benchmark",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "husky": "^4.0.10",
     "lerna": "^3.20.2",
     "lint-staged": "^10.0.1",
+    "rollup-plugin-copy": "^3.2.1",
     "prettier": "1.18.2"
   },
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "prettier": "1.18.2",
     "rollup-plugin-copy": "^3.2.1",
     "rollup-plugin-typescript2": "^0.25.3",
-    "typescript": "3.7.5"
+    "typescript": "3.7.5",
+    "ts-node": "^8.6.2"
   },
   "workspaces": [
     "benchmark",

--- a/packages/pythia-crypto/browser.cjs.d.ts
+++ b/packages/pythia-crypto/browser.cjs.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/types';

--- a/packages/pythia-crypto/browser.es.d.ts
+++ b/packages/pythia-crypto/browser.es.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/types';

--- a/packages/pythia-crypto/package.json
+++ b/packages/pythia-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@virgilsecurity/pythia-crypto",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Virgil Pythia Crypto library.",
   "main": "./dist/node.cjs.js",
   "module": "./dist/node.es.js",

--- a/packages/pythia-crypto/package.json
+++ b/packages/pythia-crypto/package.json
@@ -12,8 +12,11 @@
   "files": [
     "dist",
     "browser.cjs.js",
+    "browser.cjs.d.ts",
     "browser.es.js",
+    "browser.es.d.ts",
     "worker.cjs.js",
+    "worker.cjs.d.ts",
     "worker.es.js"
   ],
   "repository": "https://github.com/VirgilSecurity/virgil-crypto-javascript/tree/master/packages/pythia-crypto",

--- a/packages/pythia-crypto/rollup.config.js
+++ b/packages/pythia-crypto/rollup.config.js
@@ -104,6 +104,7 @@ const createNodeJsEntry = (cryptoType, format) => {
       nodeResolve({ extensions: ['.js', '.ts'] }),
       commonjs(),
       typescript({
+        objectHashIgnoreUnknownHack: true,
         useTsconfigDeclarationDir: true,
         tsconfigOverride: {
           compilerOptions: {

--- a/packages/pythia-crypto/rollup.config.js
+++ b/packages/pythia-crypto/rollup.config.js
@@ -9,36 +9,18 @@ const { terser } = require('rollup-plugin-terser');
 const typescript = require('rollup-plugin-typescript2');
 
 const packageJson = require('./package.json');
-
-const FORMAT = {
-  CJS: 'cjs',
-  ES: 'es',
-  UMD: 'umd',
-};
-
-const CRYPTO_TYPE = {
-  WASM: 'wasm',
-  ASMJS: 'asmjs',
-};
-
-const TARGET = {
-  BROWSER: 'browser',
-  WORKER: 'worker',
-  NODE: 'node',
-};
+const { createDeclarationForInnerEntry } = require('../../utils/rollup-common-configs');
+const {
+  FORMAT,
+  CRYPTO_TYPE,
+  TARGET,
+  getOutputFilename,
+  getCryptoEntryPointName,
+} = require('../../utils/build');
 
 const sourceDir = path.join(__dirname, 'src');
 const outputDir = path.join(__dirname, 'dist');
 const corePythiaDir = path.parse(require.resolve('@virgilsecurity/core-pythia')).dir;
-
-const getOutputFilename = (target, cryptoType, format) =>
-  `${target}${cryptoType === CRYPTO_TYPE.ASMJS ? '.asmjs' : ''}.${format}.js`;
-
-const getCryptoEntryPointName = (target, cryptoType, format) => {
-  const myCryptoType = cryptoType === CRYPTO_TYPE.ASMJS ? '.asmjs' : '';
-  const myFormat = format === FORMAT.UMD ? 'es' : format;
-  return `${target}${myCryptoType}.${myFormat}.js`;
-};
 
 const createBrowserEntry = (target, cryptoType, format) => {
   const pythiaEntryPoint = path.join(
@@ -79,6 +61,7 @@ const createBrowserEntry = (target, cryptoType, format) => {
           exclude: [outputDir, '**/*.test.ts'],
         },
       }),
+      createDeclarationForInnerEntry(target, cryptoType, format, outputDir),
       cryptoType === CRYPTO_TYPE.WASM &&
         copy({
           targets: [
@@ -129,6 +112,7 @@ const createNodeJsEntry = (cryptoType, format) => {
           exclude: [outputDir, '**/*.test.ts'],
         },
       }),
+      createDeclarationForInnerEntry(TARGET.NODE, cryptoType, format, outputDir),
     ],
   };
 };

--- a/packages/pythia-crypto/rollup.config.js
+++ b/packages/pythia-crypto/rollup.config.js
@@ -22,7 +22,7 @@ const sourceDir = path.join(__dirname, 'src');
 const outputDir = path.join(__dirname, 'dist');
 const corePythiaDir = path.parse(require.resolve('@virgilsecurity/core-pythia')).dir;
 
-const createBrowserEntry = (target, cryptoType, format) => {
+const createBrowserEntry = (target, cryptoType, format, declaration = false) => {
   const pythiaEntryPoint = path.join(
     '@virgilsecurity',
     'core-pythia',
@@ -56,7 +56,7 @@ const createBrowserEntry = (target, cryptoType, format) => {
         useTsconfigDeclarationDir: true,
         tsconfigOverride: {
           compilerOptions: {
-            declarationDir: path.join(outputDir, 'types'),
+            declaration,
           },
           exclude: [outputDir, '**/*.test.ts'],
         },
@@ -107,7 +107,7 @@ const createNodeJsEntry = (cryptoType, format) => {
         useTsconfigDeclarationDir: true,
         tsconfigOverride: {
           compilerOptions: {
-            declarationDir: path.join(outputDir, 'types'),
+            declaration: false,
           },
           exclude: [outputDir, '**/*.test.ts'],
         },
@@ -118,7 +118,7 @@ const createNodeJsEntry = (cryptoType, format) => {
 };
 
 module.exports = [
-  createBrowserEntry(TARGET.BROWSER, CRYPTO_TYPE.ASMJS, FORMAT.CJS),
+  createBrowserEntry(TARGET.BROWSER, CRYPTO_TYPE.ASMJS, FORMAT.CJS, true),
   createBrowserEntry(TARGET.BROWSER, CRYPTO_TYPE.ASMJS, FORMAT.ES),
   createBrowserEntry(TARGET.BROWSER, CRYPTO_TYPE.ASMJS, FORMAT.UMD),
   createBrowserEntry(TARGET.BROWSER, CRYPTO_TYPE.WASM, FORMAT.CJS),

--- a/packages/pythia-crypto/tsconfig.json
+++ b/packages/pythia-crypto/tsconfig.json
@@ -2,10 +2,14 @@
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,
+    "outDir": "dist",
+    "declarationDir": "dist/types",
+    "rootDir": "src",
     "esModuleInterop": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "strict": true,
     "target": "es2015"
-  }
+  },
+  "exclude": ["**/*.test.ts", "dist"]
 }

--- a/packages/pythia-crypto/workder.cjs.d.ts
+++ b/packages/pythia-crypto/workder.cjs.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/types';

--- a/packages/pythia-crypto/worker.es.d.ts
+++ b/packages/pythia-crypto/worker.es.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/types';

--- a/packages/virgil-crypto/browser.cjs.d.ts
+++ b/packages/virgil-crypto/browser.cjs.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/types';

--- a/packages/virgil-crypto/browser.es.d.ts
+++ b/packages/virgil-crypto/browser.es.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/types';

--- a/packages/virgil-crypto/package.json
+++ b/packages/virgil-crypto/package.json
@@ -12,9 +12,13 @@
   "files": [
     "dist",
     "browser.cjs.js",
+    "browser.cjs.d.ts",
     "browser.es.js",
+    "browser.es.d.ts",
     "worker.cjs.js",
-    "worker.es.js"
+    "worker.cjs.d.ts",
+    "worker.es.js",
+    "worker.es.d.ts"
   ],
   "repository": "https://github.com/VirgilSecurity/virgil-crypto-javascript/tree/master/packages/virgil-crypto",
   "author": "Virgil Security Inc. <support@virgilsecurity.com>",

--- a/packages/virgil-crypto/package.json
+++ b/packages/virgil-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "virgil-crypto",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Virgil JavaScript Crypto Library is a high-level cryptographic library that allows you to perform all necessary operations for secure storing and transferring data and everything required to become HIPAA and GDPR compliant.",
   "main": "./dist/node.cjs.js",
   "module": "./dist/node.es.js",

--- a/packages/virgil-crypto/rollup.config.js
+++ b/packages/virgil-crypto/rollup.config.js
@@ -22,7 +22,7 @@ const sourceDir = path.join(__dirname, 'src');
 const outputDir = path.join(__dirname, 'dist');
 const coreFoundationDir = path.parse(require.resolve('@virgilsecurity/core-foundation')).dir;
 
-const createBrowserEntry = (target, cryptoType, format) => {
+const createBrowserEntry = (target, cryptoType, format, declaration = false) => {
   const foundationEntryPoint = path.join(
     '@virgilsecurity',
     'core-foundation',
@@ -56,9 +56,8 @@ const createBrowserEntry = (target, cryptoType, format) => {
         useTsconfigDeclarationDir: true,
         tsconfigOverride: {
           compilerOptions: {
-            declarationDir: path.join(outputDir, 'types'),
+            declaration,
           },
-          exclude: [outputDir, '**/*.test.ts'],
         },
       }),
       createDeclarationForInnerEntry(target, cryptoType, format, outputDir),
@@ -104,12 +103,12 @@ const createNodeJsEntry = (cryptoType, format) => {
       nodeResolve({ extensions: ['.js', '.ts'] }),
       commonjs(),
       typescript({
+        objectHashIgnoreUnknownHack: true,
         useTsconfigDeclarationDir: true,
         tsconfigOverride: {
           compilerOptions: {
-            declarationDir: path.join(outputDir, 'types'),
+            declaration: false,
           },
-          exclude: [outputDir, '**/*.test.ts'],
         },
       }),
       createDeclarationForInnerEntry(TARGET.NODE, cryptoType, format, outputDir),
@@ -118,16 +117,16 @@ const createNodeJsEntry = (cryptoType, format) => {
 };
 
 module.exports = [
-  createBrowserEntry(TARGET.BROWSER, CRYPTO_TYPE.ASMJS, FORMAT.CJS),
-  createBrowserEntry(TARGET.BROWSER, CRYPTO_TYPE.ASMJS, FORMAT.ES),
-  createBrowserEntry(TARGET.BROWSER, CRYPTO_TYPE.ASMJS, FORMAT.UMD),
-  createBrowserEntry(TARGET.BROWSER, CRYPTO_TYPE.WASM, FORMAT.CJS),
-  createBrowserEntry(TARGET.BROWSER, CRYPTO_TYPE.WASM, FORMAT.ES),
-  createBrowserEntry(TARGET.BROWSER, CRYPTO_TYPE.WASM, FORMAT.UMD),
   createNodeJsEntry(CRYPTO_TYPE.ASMJS, FORMAT.CJS),
   createNodeJsEntry(CRYPTO_TYPE.ASMJS, FORMAT.ES),
   createNodeJsEntry(CRYPTO_TYPE.WASM, FORMAT.CJS),
   createNodeJsEntry(CRYPTO_TYPE.WASM, FORMAT.ES),
+  createBrowserEntry(TARGET.BROWSER, CRYPTO_TYPE.WASM, FORMAT.CJS, true),
+  createBrowserEntry(TARGET.BROWSER, CRYPTO_TYPE.WASM, FORMAT.ES),
+  createBrowserEntry(TARGET.BROWSER, CRYPTO_TYPE.WASM, FORMAT.UMD),
+  createBrowserEntry(TARGET.BROWSER, CRYPTO_TYPE.ASMJS, FORMAT.CJS),
+  createBrowserEntry(TARGET.BROWSER, CRYPTO_TYPE.ASMJS, FORMAT.ES),
+  createBrowserEntry(TARGET.BROWSER, CRYPTO_TYPE.ASMJS, FORMAT.UMD),
   createBrowserEntry(TARGET.WORKER, CRYPTO_TYPE.ASMJS, FORMAT.CJS),
   createBrowserEntry(TARGET.WORKER, CRYPTO_TYPE.ASMJS, FORMAT.ES),
   createBrowserEntry(TARGET.WORKER, CRYPTO_TYPE.ASMJS, FORMAT.UMD),

--- a/packages/virgil-crypto/rollup.config.js
+++ b/packages/virgil-crypto/rollup.config.js
@@ -9,36 +9,18 @@ const { terser } = require('rollup-plugin-terser');
 const typescript = require('rollup-plugin-typescript2');
 
 const packageJson = require('./package.json');
-
-const FORMAT = {
-  CJS: 'cjs',
-  ES: 'es',
-  UMD: 'umd',
-};
-
-const CRYPTO_TYPE = {
-  WASM: 'wasm',
-  ASMJS: 'asmjs',
-};
-
-const TARGET = {
-  BROWSER: 'browser',
-  WORKER: 'worker',
-  NODE: 'node',
-};
+const { createDeclarationForInnerEntry } = require('../../utils/rollup-common-configs');
+const {
+  FORMAT,
+  CRYPTO_TYPE,
+  TARGET,
+  getOutputFilename,
+  getCryptoEntryPointName,
+} = require('../../utils/build');
 
 const sourceDir = path.join(__dirname, 'src');
 const outputDir = path.join(__dirname, 'dist');
 const coreFoundationDir = path.parse(require.resolve('@virgilsecurity/core-foundation')).dir;
-
-const getOutputFilename = (target, cryptoType, format) =>
-  `${target}${cryptoType === CRYPTO_TYPE.ASMJS ? '.asmjs' : ''}.${format}.js`;
-
-const getCryptoEntryPointName = (target, cryptoType, format) => {
-  const myCryptoType = cryptoType === CRYPTO_TYPE.ASMJS ? '.asmjs' : '';
-  const myFormat = format === FORMAT.UMD ? 'es' : format;
-  return `${target}${myCryptoType}.${myFormat}.js`;
-};
 
 const createBrowserEntry = (target, cryptoType, format) => {
   const foundationEntryPoint = path.join(
@@ -79,6 +61,7 @@ const createBrowserEntry = (target, cryptoType, format) => {
           exclude: [outputDir, '**/*.test.ts'],
         },
       }),
+      createDeclarationForInnerEntry(target, cryptoType, format, outputDir),
       cryptoType === CRYPTO_TYPE.WASM &&
         copy({
           targets: [

--- a/packages/virgil-crypto/rollup.config.js
+++ b/packages/virgil-crypto/rollup.config.js
@@ -112,6 +112,7 @@ const createNodeJsEntry = (cryptoType, format) => {
           exclude: [outputDir, '**/*.test.ts'],
         },
       }),
+      createDeclarationForInnerEntry(TARGET.NODE, cryptoType, format, outputDir),
     ],
   };
 };

--- a/packages/virgil-crypto/tsconfig.json
+++ b/packages/virgil-crypto/tsconfig.json
@@ -2,10 +2,14 @@
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,
+    "outDir": "dist",
+    "declarationDir": "dist/types",
+    "rootDir": "src",
     "esModuleInterop": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "strict": true,
     "target": "es2015"
-  }
+  },
+  "exclude": ["**/*.test.ts", "dist"]
 }

--- a/packages/virgil-crypto/worker.cjs.d.ts
+++ b/packages/virgil-crypto/worker.cjs.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/types';

--- a/packages/virgil-crypto/worker.es.d.ts
+++ b/packages/virgil-crypto/worker.es.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/types';

--- a/utils/build.js
+++ b/utils/build.js
@@ -1,0 +1,33 @@
+const FORMAT = {
+  CJS: 'cjs',
+  ES: 'es',
+  UMD: 'umd',
+};
+
+const CRYPTO_TYPE = {
+  WASM: 'wasm',
+  ASMJS: 'asmjs',
+};
+
+const TARGET = {
+  BROWSER: 'browser',
+  WORKER: 'worker',
+  NODE: 'node',
+};
+
+const getOutputFilename = (target, cryptoType, format, extension = 'js') =>
+  `${target}${cryptoType === CRYPTO_TYPE.ASMJS ? '.asmjs' : ''}.${format}.${extension}`;
+
+const getCryptoEntryPointName = (target, cryptoType, format) => {
+  const myCryptoType = cryptoType === CRYPTO_TYPE.ASMJS ? '.asmjs' : '';
+  const myFormat = format === FORMAT.UMD ? 'es' : format;
+  return `${target}${myCryptoType}.${myFormat}.js`;
+};
+
+module.exports = {
+  FORMAT,
+  CRYPTO_TYPE,
+  TARGET,
+  getOutputFilename,
+  getCryptoEntryPointName,
+};

--- a/utils/declaration.d.ts.template
+++ b/utils/declaration.d.ts.template
@@ -1,0 +1,1 @@
+export * from './types';

--- a/utils/rollup-common-configs.js
+++ b/utils/rollup-common-configs.js
@@ -1,0 +1,20 @@
+const copy = require('rollup-plugin-copy');
+const { getOutputFilename } = require('./build');
+const declarationTemplatePath = require.resolve('./declaration.d.ts.template');
+
+console.log('declarationTemplatePath', declarationTemplatePath);
+
+const createDeclarationForInnerEntry = (target, cryptoType, format, outputDir) =>
+  copy({
+    targets: [
+      {
+        src: declarationTemplatePath,
+        dest: outputDir,
+        rename: getOutputFilename(target, cryptoType, format, 'd.ts'),
+      },
+    ],
+  });
+
+module.exports = {
+  createDeclarationForInnerEntry,
+};

--- a/utils/rollup-common-configs.js
+++ b/utils/rollup-common-configs.js
@@ -2,8 +2,6 @@ const copy = require('rollup-plugin-copy');
 const { getOutputFilename } = require('./build');
 const declarationTemplatePath = require.resolve('./declaration.d.ts.template');
 
-console.log('declarationTemplatePath', declarationTemplatePath);
-
 const createDeclarationForInnerEntry = (target, cryptoType, format, outputDir) =>
   copy({
     targets: [


### PR DESCRIPTION
### Pythia Crypto
- bump to v1.1.3

### Virgil Crypto
- bump to v4.2.2

### Changelog:
- Fix importing non default bundle in typescript
![image](https://user-images.githubusercontent.com/8099672/82657835-b22ddc00-9c2e-11ea-90ee-c9c6bc75a958.png)
We have bundles for:
target: Browser, Web Worker, Node.JS
crypto type: Asm.JS, Web Assebmly
format: commonJS, UMD, Ecma Script